### PR TITLE
Don't exit on a missing message file

### DIFF
--- a/cgi/message.go
+++ b/cgi/message.go
@@ -66,7 +66,6 @@ func newMessage(filedir, fname string) (Message, error) {
 	}
 	if dat == nil {
 		err := errors.New("message file was not found")
-		log.Fatal(err)
 		return nil, err
 	}
 


### PR DESCRIPTION
`SearchMessage`が他の候補を探す前に`log.Fatal`で終了してしまっていました。