### PR TITLE
add update-bindata target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+
+update-bindata:
+	go-bindata -pkg util -o util/bindata.go $(shell find www/ file/ gou_template/ -type d)
+


### PR DESCRIPTION
www, file, gou_templateディレクトリの中身を書き換えたとき、`util/bindata.go`も更新しなければなりません。
その更新方法がどこにも書かれていなかったため、Makefileに書いておきました。